### PR TITLE
[FEAT] 예약 API 구현 #16

### DIFF
--- a/airbnbClone/.gitignore
+++ b/airbnbClone/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/generated/
 
 ### STS ###
 .apt_generated

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/controller/ReservationController.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/controller/ReservationController.java
@@ -22,8 +22,8 @@ public class ReservationController {
     private final ReservationService reservationService;
 
     @PostMapping(value = "/{accommodationId}/book") //숙소 예약 -> 프론트에서  checkIn/checkOut/totalPrice/guest 받아서 예약 진행
-    public String book(@PathVariable Long accommodationId, @RequestBody BookRequest request) {
-        return reservationService.bookAccommodation(accommodationId, request);
+    public void book(@PathVariable Long accommodationId, @RequestBody BookRequest request) {
+        reservationService.bookAccommodation(accommodationId, request);
     }
 
     @GetMapping(value = "/user/reservations") // 게스트 - 숙소 예약 전체 조회

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/controller/ReservationController.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/controller/ReservationController.java
@@ -1,7 +1,49 @@
 package dbDive.airbnbClone.api.reservation.controller;
 
-import org.springframework.stereotype.Controller;
+import dbDive.airbnbClone.api.reservation.dto.SelectReservationDto;
+import dbDive.airbnbClone.api.reservation.dto.request.BookRequest;
+import dbDive.airbnbClone.api.reservation.dto.response.HostTotalAccommodationResponse;
+import dbDive.airbnbClone.api.reservation.dto.response.TotalAccommodationResponse;
+import dbDive.airbnbClone.api.reservation.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
 public class ReservationController {
+    /**
+     * TODO
+     *
+     * @AuthenticationPrincipal 넣어주기
+     */
+    private final ReservationService reservationService;
+
+    @PostMapping(value = "/{accommodationId}/book") //숙소 예약 -> 프론트에서  checkIn/checkOut/totalPrice/guest 받아서 예약 진행
+    public String book(@PathVariable Long accommodationId, @RequestBody BookRequest request) {
+        return reservationService.bookAccommodation(accommodationId, request);
+    }
+
+    @GetMapping(value = "/user/reservations") // 게스트 - 숙소 예약 전체 조회
+    public TotalAccommodationResponse allAccommodations(Pageable pageable) {
+        return reservationService.allAccommodations(pageable);
+    }
+
+    @GetMapping("/user/reservations/{reservationId}") // 게스트 - 숙소 예약 단건 조회
+    public SelectReservationDto selectAccommodation(@PathVariable Long reservationId) {
+        return reservationService.selectAccommodations(reservationId);
+    }
+
+    @DeleteMapping("/accommodation/{reservationId}")
+    public void deleteAccommodation(@PathVariable Long reservationId) {
+        reservationService.deleteAccommodation(reservationId);
+    }
+
+
+    @GetMapping("/host/{userId}")
+    public HostTotalAccommodationResponse hostAllAccommodations(@PathVariable Long userId, Pageable pageable) {
+        return reservationService.hostAllAccommodations(userId, pageable);
+    }
 }

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/HostReservationDto.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/HostReservationDto.java
@@ -1,0 +1,37 @@
+package dbDive.airbnbClone.api.reservation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+public class HostReservationDto {
+    private Long reservationId;
+    private Long userId;
+    private String username;
+    private LocalDate checkIn;
+    private LocalDate checkOut;
+    private Long accommodationId;
+    private String acmdName;
+    private String images;
+    private String status;
+    private int totalPrice;
+
+
+
+    public HostReservationDto(Long reservationId,Long userId, String username, LocalDate checkIn, LocalDate checkOut, Long accommodationId, String acmdName, String images, String status, int totalPrice) {
+        this.reservationId = reservationId;
+        this.userId = userId;
+        this.username = username;
+        this.checkIn = checkIn;
+        this.checkOut = checkOut;
+        this.accommodationId = accommodationId;
+        this.acmdName = acmdName;
+        this.images = images;
+        this.status = status;
+        this.totalPrice = totalPrice;
+    }
+}

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/ReservationDto.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/ReservationDto.java
@@ -1,0 +1,28 @@
+package dbDive.airbnbClone.api.reservation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+public class ReservationDto {
+    private Long accommodationId;
+    private Long userId;
+    private String city;
+    private String username;
+    private LocalDate checkIn;
+    private LocalDate checkOut;
+    private List<String> images;
+
+    public ReservationDto(Long accommodationId,Long userId, String city, String username, LocalDate checkIn, LocalDate checkOut) {
+        this.accommodationId = accommodationId;
+        this.userId = userId;
+        this.city = city;
+        this.username = username;
+        this.checkIn = checkIn;
+        this.checkOut = checkOut;
+    }
+}

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/SelectReservationDto.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/SelectReservationDto.java
@@ -1,0 +1,31 @@
+package dbDive.airbnbClone.api.reservation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+public class SelectReservationDto {
+    private List<String> images;
+    private Long accommodationId;
+    private LocalDate checkIn;
+    private LocalDate checkOut;
+    private Long userId;
+    private String username;
+    private String userDescription;
+    private int totalPrice;
+
+    public SelectReservationDto(Long accommodationId,LocalDate checkIn, LocalDate checkOut, Long userId, String username, String userDescription, int totalPrice) {
+        this.accommodationId = accommodationId;
+        this.checkIn = checkIn;
+        this.checkOut = checkOut;
+        this.userId = userId;
+        this.username = username;
+        this.userDescription = userDescription;
+        this.totalPrice = totalPrice;
+    }
+}

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/request/BookRequest.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/request/BookRequest.java
@@ -1,0 +1,22 @@
+package dbDive.airbnbClone.api.reservation.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class BookRequest {
+    private LocalDate checkIn;
+    private LocalDate checkOut;
+    private int totalPrice;
+    private int guest;
+
+    @Builder
+    public BookRequest(LocalDate checkIn, LocalDate checkOut, int totalPrice, int guest) {
+        this.checkIn = checkIn;
+        this.checkOut = checkOut;
+        this.totalPrice = totalPrice;
+        this.guest = guest;
+    }
+}

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/response/HostTotalAccommodationResponse.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/response/HostTotalAccommodationResponse.java
@@ -1,0 +1,21 @@
+package dbDive.airbnbClone.api.reservation.dto.response;
+
+import dbDive.airbnbClone.api.reservation.dto.HostReservationDto;
+import lombok.Getter;
+import org.springframework.data.domain.PageImpl;
+
+import java.util.List;
+
+@Getter
+public class HostTotalAccommodationResponse {
+
+    private List<HostReservationDto> reservations;
+    private int totalPage;
+    private int currentPage;
+
+    public HostTotalAccommodationResponse(PageImpl<HostReservationDto> reservations) {
+        this.reservations = reservations.getContent();
+        this.totalPage = reservations.getTotalPages();
+        this.currentPage = reservations.getNumber();
+    }
+}

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/response/SelectAccommodationResponse.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/response/SelectAccommodationResponse.java
@@ -1,0 +1,23 @@
+package dbDive.airbnbClone.api.reservation.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class SelectAccommodationResponse {
+    private String imageUrl;
+    private int checkInDate;
+    private int checkOutDate;
+    private Long userId;
+    private String username;
+    private String userDescription;
+    private int totalPrice;
+
+    public SelectAccommodationResponse(int checkInDate, int checkOutDate, Long userId, String username, String userDescription, int totalPrice) {
+        this.checkInDate = checkInDate;
+        this.checkOutDate = checkOutDate;
+        this.userId = userId;
+        this.username = username;
+        this.userDescription = userDescription;
+        this.totalPrice = totalPrice;
+    }
+}

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/response/TotalAccommodationResponse.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/dto/response/TotalAccommodationResponse.java
@@ -1,0 +1,21 @@
+package dbDive.airbnbClone.api.reservation.dto.response;
+
+import dbDive.airbnbClone.api.reservation.dto.ReservationDto;
+import lombok.Getter;
+import org.springframework.data.domain.PageImpl;
+
+import java.util.List;
+@Getter
+public class TotalAccommodationResponse {
+
+    private List<ReservationDto> reservations;
+    private int totalPage;
+    private int currentPage;
+
+    public TotalAccommodationResponse(PageImpl<ReservationDto> reservations) {
+        this.reservations = reservations.getContent();
+        this.totalPage = reservations.getTotalPages();
+        this.currentPage = reservations.getNumber();
+    }
+}
+

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/service/ReservationService.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/service/ReservationService.java
@@ -26,7 +26,7 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
 
     @Transactional
-    public String bookAccommodation(Long accommodationId, BookRequest request) {
+    public void bookAccommodation(Long accommodationId, BookRequest request) {
 
         //숙소 예약 -> 프론트에서  checkIn/checkOut/totalPrice/guest 받아서 예약 진행
         Accommodation findAcmd = accommodationRepository.findById(accommodationId).orElseThrow(() -> new GlobalException("존재하지 않는 숙소입니다,"));
@@ -38,7 +38,6 @@ public class ReservationService {
                 .accommodation(findAcmd)
                 .build();
         reservationRepository.save(reservation);
-        return "redirect:/api/auth/user/reservations/" + accommodationId;
     }
 
     public TotalAccommodationResponse allAccommodations(Pageable pageable) {

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/service/ReservationService.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/api/reservation/service/ReservationService.java
@@ -1,11 +1,79 @@
 package dbDive.airbnbClone.api.reservation.service;
 
+import dbDive.airbnbClone.api.reservation.dto.HostReservationDto;
+import dbDive.airbnbClone.api.reservation.dto.ReservationDto;
+import dbDive.airbnbClone.api.reservation.dto.SelectReservationDto;
+import dbDive.airbnbClone.api.reservation.dto.request.BookRequest;
+import dbDive.airbnbClone.api.reservation.dto.response.HostTotalAccommodationResponse;
+import dbDive.airbnbClone.api.reservation.dto.response.TotalAccommodationResponse;
+import dbDive.airbnbClone.common.GlobalException;
+import dbDive.airbnbClone.entity.accommodation.Accommodation;
+import dbDive.airbnbClone.entity.resevation.Reservation;
+import dbDive.airbnbClone.repository.accommodation.AccommodationRepository;
+import dbDive.airbnbClone.repository.reservation.ReservationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
+
+    private final AccommodationRepository accommodationRepository;
+    private final ReservationRepository reservationRepository;
+
+    @Transactional
+    public String bookAccommodation(Long accommodationId, BookRequest request) {
+
+        //숙소 예약 -> 프론트에서  checkIn/checkOut/totalPrice/guest 받아서 예약 진행
+        Accommodation findAcmd = accommodationRepository.findById(accommodationId).orElseThrow(() -> new GlobalException("존재하지 않는 숙소입니다,"));
+        Reservation reservation = Reservation.builder()
+                .checkIn(request.getCheckIn())
+                .checkOut(request.getCheckOut())
+                .totalPrice(request.getTotalPrice())
+                .guest(request.getGuest())
+                .accommodation(findAcmd)
+                .build();
+        reservationRepository.save(reservation);
+        return "redirect:/api/auth/user/reservations/" + accommodationId;
+    }
+
+    public TotalAccommodationResponse allAccommodations(Pageable pageable) {
+
+        PageImpl<ReservationDto> result = reservationRepository.findAllReservations(pageable);
+        return new TotalAccommodationResponse(result);
+
+    }
+
+    public SelectReservationDto selectAccommodations(Long reservationId) {
+        // 게스트 - 숙소 예약 단건 조회
+        SelectReservationDto selectReservation = reservationRepository.findSelectReservation(reservationId);
+        return selectReservation;
+
+    }
+
+    public void deleteAccommodation(Long reservationId) {
+        // 게스트 - 예약 취소
+        Reservation findReservation = reservationRepository.findById(reservationId).orElseThrow();
+        reservationRepository.delete(findReservation);
+    }
+
+    public HostTotalAccommodationResponse hostAllAccommodations(Long userId, Pageable pageable) {
+        // 호스트 - 예약 조회
+        /**
+         * 1. 등록된 accommodation에서 userId로 accommodationId 찾기
+         * 2. accommodationId 으로 같은 accommodationId 을 가지고 있는 acmd_image, reservation 찾기
+         * 3. 상태 체크
+         * - checkOut > LocalDate.now() && isDeleted == false, 예약중
+         * - checkOut < LocalDate.now() && isDeleted == false, 이용완료
+         * - isDeleted == true, 취소
+         */
+
+        PageImpl<HostReservationDto> hostReservation = reservationRepository.findHostReservation(userId, pageable);
+        return new HostTotalAccommodationResponse(hostReservation);
+    }
 
 }

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/entity/resevation/Reservation.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/entity/resevation/Reservation.java
@@ -4,6 +4,7 @@ import dbDive.airbnbClone.entity.BaseTimeEntity;
 import dbDive.airbnbClone.entity.accommodation.Accommodation;
 import dbDive.airbnbClone.entity.user.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +18,7 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE Reservation SET is_deleted = true WHERE id = ?")
-@Where(clause = "is_deleted = false")
+//@Where(clause = "is_deleted = false")
 public class Reservation extends BaseTimeEntity {
 
     @Id

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/repository/reservation/ReservationRepository.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/repository/reservation/ReservationRepository.java
@@ -3,5 +3,5 @@ package dbDive.airbnbClone.repository.reservation;
 import dbDive.airbnbClone.entity.resevation.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+public interface ReservationRepository extends JpaRepository<Reservation,Long>,ReservationRepositoryCustom {
 }

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/repository/reservation/ReservationRepositoryCustom.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/repository/reservation/ReservationRepositoryCustom.java
@@ -1,0 +1,18 @@
+package dbDive.airbnbClone.repository.reservation;
+
+import dbDive.airbnbClone.api.reservation.dto.HostReservationDto;
+import dbDive.airbnbClone.api.reservation.dto.ReservationDto;
+import dbDive.airbnbClone.api.reservation.dto.SelectReservationDto;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ReservationRepositoryCustom {
+    PageImpl<ReservationDto> findAllReservations(Pageable pageable);
+
+    SelectReservationDto findSelectReservation(Long reservationId);
+
+    PageImpl<HostReservationDto> findHostReservation(Long userId, Pageable pageable);
+
+}

--- a/airbnbClone/src/main/java/dbDive/airbnbClone/repository/reservation/ReservationRepositoryImpl.java
+++ b/airbnbClone/src/main/java/dbDive/airbnbClone/repository/reservation/ReservationRepositoryImpl.java
@@ -1,0 +1,150 @@
+package dbDive.airbnbClone.repository.reservation;
+
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dbDive.airbnbClone.api.reservation.dto.HostReservationDto;
+import dbDive.airbnbClone.api.reservation.dto.ReservationDto;
+import dbDive.airbnbClone.api.reservation.dto.SelectReservationDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static dbDive.airbnbClone.entity.accommodation.QAccommodation.accommodation;
+import static dbDive.airbnbClone.entity.accommodation.QAcmdImage.acmdImage;
+import static dbDive.airbnbClone.entity.resevation.QReservation.reservation;
+import static dbDive.airbnbClone.entity.user.QUser.user;
+
+@RequiredArgsConstructor
+public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public PageImpl<ReservationDto> findAllReservations(Pageable pageable) {
+        List<ReservationDto> reservations = queryFactory
+                .select(Projections.constructor(ReservationDto.class,
+                        accommodation.id,
+                        user.id,
+                        accommodation.mainAddress,
+                        user.username,
+                        reservation.checkIn,
+                        reservation.checkOut))
+                .from(accommodation)
+                .join(reservation).on(reservation.accommodation.id.eq(accommodation.id))
+                .join(user).on(accommodation.user.id.eq(user.id))
+                .where(reservation.isDeleted.eq(false))
+                .orderBy(reservation.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        List<Long> resultId = new ArrayList<>();
+        for (ReservationDto dto : reservations) {
+            resultId.add(dto.getAccommodationId());
+        }
+
+        Map<Long, List<String>> acmdImages = queryFactory
+                .select(accommodation.id, acmdImage.imageUrl)
+                .from(accommodation)
+                .join(acmdImage).on(accommodation.id.eq(acmdImage.accommodation.id))
+                .where(accommodation.id.in(resultId))
+                .orderBy(acmdImage.id.asc())
+                .transform(GroupBy.groupBy(accommodation.id)
+                        .as(GroupBy.list(acmdImage.imageUrl))
+                );
+
+        reservations.forEach(r ->
+                r.setImages(acmdImages.getOrDefault(r.getAccommodationId(), new ArrayList<>()))
+        );
+
+        Long count = queryFactory.select(accommodation.count())
+                .from(accommodation)
+                .fetchOne();
+
+        return new PageImpl<ReservationDto>(reservations, pageable, count);
+    }
+
+    @Override
+    public SelectReservationDto findSelectReservation(Long reservationId) {
+        SelectReservationDto selectReservationDto = queryFactory
+                .select(Projections.constructor(SelectReservationDto.class,
+                        accommodation.id,
+                        reservation.checkIn,
+                        reservation.checkOut,
+                        user.id,
+                        user.username,
+                        user.userDescription,
+                        reservation.totalPrice))
+                .from(reservation)
+                .join(user).on(user.id.eq(reservation.user.id))
+                .join(accommodation).on(accommodation.id.eq(reservation.accommodation.id))
+                .where(reservation.id.eq(reservationId), (reservation.isDeleted.eq(false)))
+                .orderBy(reservation.createdAt.desc())
+                .fetchOne();
+        Long accommodationId = selectReservationDto.getAccommodationId();
+
+        List<String> acmdImages = queryFactory
+                .select(
+                        acmdImage.imageUrl)
+                .from(acmdImage)
+                .where(acmdImage.accommodation.id.eq(accommodationId))
+                .fetch();
+
+        selectReservationDto.setImages(acmdImages);
+        return selectReservationDto;
+    }
+
+    @Override
+    public PageImpl<HostReservationDto> findHostReservation(Long userId, Pageable pageable) {
+        /**
+         * 1. 등록된 accommodation에서 userId로 accommodationId 찾기
+         * 2. accommodationId 으로 같은 accommodationId 을 가지고 있는 acmd_image, reservation 찾기
+         * 3. 상태 체크
+         * - checkOut > LocalDate.now() && isDeleted == false, 예약중
+         * - checkOut < LocalDate.now() && isDeleted == false, 이용완료
+         * - isDeleted == true, 취소
+         */
+
+        List<HostReservationDto> hostReservationDto = queryFactory
+                .select(Projections.constructor(HostReservationDto.class,
+                        reservation.id,
+                        user.id,
+                        user.username,
+                        reservation.checkIn,
+                        reservation.checkOut,
+                        accommodation.id,
+                        accommodation.acmdName,
+                        acmdImage.imageUrl.min(),
+                        new CaseBuilder()
+                                .when(reservation.checkOut.after(LocalDate.now()).and(reservation.isDeleted.eq(false))).then("예약 중")
+                                .when(reservation.checkOut.before(LocalDate.now()).and(reservation.isDeleted.eq(false))).then("이용완료")
+                                .otherwise("예약 취소"),
+                        reservation.totalPrice))
+                .from(reservation)
+                .join(user).on(user.id.eq(reservation.user.id))
+                .join(accommodation).on(accommodation.id.eq(reservation.accommodation.id))
+                .join(acmdImage).on(acmdImage.accommodation.id.eq(accommodation.id))
+                .where(accommodation.user.id.eq(userId))
+                .groupBy(reservation.id)
+                .orderBy(reservation.createdAt.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory.select(reservation.count())
+                .from(reservation)
+                .join(accommodation).on(reservation.accommodation.id.eq(accommodation.id))
+                .where(accommodation.user.id.eq(userId))
+                .fetchOne();
+
+        return new PageImpl<HostReservationDto>(hostReservationDto, pageable, count);
+    }
+}
+
+


### PR DESCRIPTION
### [issue]

**1. Reservation Entity에서 @Where(clause = "is_deleted = false") 삭제**
- 호스트가 숙소 예약을 조회할 때, status가 예약중/이용완료/예약취소 로 나뉘어져 있는데, @Where(clause = "is_deleted = false")가 붙어 있으면 예약취소 상태를 표시할 수 없음 
- 조회 시 is_deleted가 true인 값은 조회하지 않도록 쿼리에 조건문 추가

**2. 예약 단건 조회 api명 수정**
- 예약 단건 조회인데, api가 /api/auth/user/reservations/{accommodationId} 로 되어있음. 
- {reservationId}로 수정

**3. 호스트 예약 조회**
- 호스트 예약 조회 시, 예약에 대한 id를 추가함(reservation_id)

**4. 숙박예약**
- 숙박 예약 로직 맞는지..도와주세요!!